### PR TITLE
fix(validation): RFC-5322 compliant email validation

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -6,7 +6,8 @@ export default async function isDisposable(
   email: string,
   { remote = false } = {},
 ) {
-  if (/^[\w\-\.]+@([\w-]+\.)+[\w-]{2,4}$/.test(email) === false) {
+  const ere = /^(?:[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*|"(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21\x23-\x5b\x5d-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])*")@(?:(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?|\[(?:(?:(2(5[0-5]|[0-4][0-9])|1[0-9][0-9]|[1-9]?[0-9]))\.){3}(?:(2(5[0-5]|[0-4][0-9])|1[0-9][0-9]|[1-9]?[0-9])|[a-z0-9-]*[a-z0-9]:(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21-\x5a\x53-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])+)\])$/
+  if (ere.test(email) === false) {
     throw new Error('invalid email')
   }
 

--- a/mod.ts
+++ b/mod.ts
@@ -6,7 +6,7 @@ export default async function isDisposable(
   email: string,
   { remote = false } = {},
 ) {
-  const ere = /^(?:[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*|"(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21\x23-\x5b\x5d-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])*")@(?:(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?|\[(?:(?:(2(5[0-5]|[0-4][0-9])|1[0-9][0-9]|[1-9]?[0-9]))\.){3}(?:(2(5[0-5]|[0-4][0-9])|1[0-9][0-9]|[1-9]?[0-9])|[a-z0-9-]*[a-z0-9]:(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21-\x5a\x53-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])+)\])$/
+  const ere = /^([A-Z0-9_+-]+\.?)*[A-Z0-9_+-]@([A-Z0-9][A-Z0-9\-]*\.)+[A-Z]{2,}$/i;
   if (ere.test(email) === false) {
     throw new Error('invalid email')
   }

--- a/mod.ts
+++ b/mod.ts
@@ -6,8 +6,9 @@ export default async function isDisposable(
   email: string,
   { remote = false } = {},
 ) {
-  const ere = /^([A-Z0-9_+-]+\.?)*[A-Z0-9_+-]@([A-Z0-9][A-Z0-9\-]*\.)+[A-Z]{2,}$/i;
-  if (ere.test(email) === false) {
+  const regex = /^([A-Z0-9_+-]+\.?)*[A-Z0-9_+-]@([A-Z0-9][A-Z0-9\-]*\.)+[A-Z]{2,}$/i
+  
+  if (regex.test(email) === false) {
     throw new Error('invalid email')
   }
 


### PR DESCRIPTION
The current email validation is insufficient as it will fail with commonly occurring patterns (john+doe@example.com).  This PR adds a more robust regex which more closely aligns with the RFC-5322 standard.